### PR TITLE
Update get-hook-script.js

### DIFF
--- a/src/utils/get-hook-script.js
+++ b/src/utils/get-hook-script.js
@@ -57,7 +57,7 @@ module.exports = function getHookScript(hookName, relativePath, runnerPath) {
       }
 
       has_hook_script () {
-        [ -f package.json ] && cat package.json | grep -q "\\"$1\\"[[:space:]]*:"
+        [ -f package.json ] && cat package.json | grep -q "\"$1\"[[:space:]]*:"
       }
 
       # OS X and Linux only


### PR DESCRIPTION
The 'has_hook_script' didn't work in macOS by found hooks with the regexp, maybe there's any mistake? Command grep doesn't need '\' to build the regexp. Or need some compatibility.

I modified the `"\\"pre-commit\\"[[:space:]]*:"` to ``"\"pre-commit\"[[:space:]]*:"`` and it works.