### PR TITLE
Add support to nvm Brew installation on osx

### DIFF
--- a/src/utils/get-hook-script.js
+++ b/src/utils/get-hook-script.js
@@ -28,8 +28,13 @@ function platformSpecific() {
         # Node standard installation path /usr/local
         export PATH="$PATH:/usr/local/bin:/usr/local"
 
-        # Try to load nvm using path of standard installation
-        load_nvm ${home}/.nvm
+        # Try to load nvm using path of standard installation ${home}/.nvm and
+        # Brew standard installation /usr/local/opt/nvm
+        if [[ -d "${home}/.nvm" ]]; then
+          load_nvm "${home}/.nvm"
+        elif [[ -d "/usr/local/opt/nvm" ]]; then
+          load_nvm "/usr/local/opt/nvm"
+        else
         run_nvm`
     )
 


### PR DESCRIPTION
Well, there are arguments about nvm officially not supporting [2] [3] homebrew installation [1] and even from the upstream [4].
However, there are people who are using and know how to tackle it.

[1]: https://formulae.brew.sh/formula/nvm
[2]: https://github.com/nvm-sh/nvm/commit/1a6f85da469b2a4f42333ddb43ce92b3f0c078f8
[3]: https://github.com/zsh-users/zsh-completions/issues/680
[4]: https://github.com/typicode/husky/commit/503fba80139c693d8304bf529974565f5889416c