### PR TITLE
Add support for pnpm

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -11,7 +11,6 @@ const findDepDir = require('../src/utils/find-dep-dir')
 
 function install(rootDir, dir) {
   const depDir = findDepDir(path.join(rootDir, dir))
-  console.log('=====================', depDir)
   installFrom(depDir)
 }
 

--- a/bin/install.js
+++ b/bin/install.js
@@ -4,6 +4,7 @@
 const path = require('path')
 const isCI = require('is-ci')
 const installFrom = require('../src/install')
+const findDepDir = require('../src/utils/find-dep-dir')
 
 if (isCI && !process.env.HUSKY_IGNORE_CI && !process.env.YORKIE_IGNORE_CI) {
   console.log('CI detected, skipping Git hooks installation')
@@ -20,5 +21,5 @@ if (process.env.HUSKY_SKIP_INSTALL || process.env.YORKIE_SKIP_INSTALL) {
 
 console.log('setting up Git hooks')
 
-const depDir = path.join(__dirname, '..')
+const depDir = findDepDir()
 installFrom(depDir)

--- a/bin/install.js
+++ b/bin/install.js
@@ -21,5 +21,5 @@ if (process.env.HUSKY_SKIP_INSTALL || process.env.YORKIE_SKIP_INSTALL) {
 
 console.log('setting up Git hooks')
 
-const depDir = findDepDir()
+const depDir = findDepDir(path.join(__dirname, '..'))
 installFrom(depDir)

--- a/bin/uninstall.js
+++ b/bin/uninstall.js
@@ -3,9 +3,10 @@
 // Run when package is uninstalled
 const path = require('path')
 const uninstallFrom = require('../src/uninstall')
+const findDepDir = require('../src/utils/find-dep-dir')
 
 console.log('husky')
 console.log('uninstalling Git hooks')
 
-const depDir = path.join(__dirname, '..')
+const depDir = findDepDir()
 uninstallFrom(depDir)

--- a/bin/uninstall.js
+++ b/bin/uninstall.js
@@ -8,5 +8,5 @@ const findDepDir = require('../src/utils/find-dep-dir')
 console.log('husky')
 console.log('uninstalling Git hooks')
 
-const depDir = findDepDir()
+const depDir = findDepDir(path.join(__dirname, '..'))
 uninstallFrom(depDir)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "yorkie",
+  "name": "yorkie-pnpm",
   "version": "2.0.0",
-  "description": "githooks management forked from husky",
+  "description": "githooks management forked from yorkie",
   "engines": {
     "node": ">=4"
   },
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/yyx990803/yorkie.git"
+    "url": "git://github.com/sishenhei7/yorkie-pnpm.git"
   },
   "keywords": [
     "git",
@@ -31,13 +31,14 @@
   ],
   "authors": [
     "Typicode <typicode@gmail.com>",
-    "Evan You"
+    "Evan You",
+    "sishenhei7"
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/yyx990803/yorkie/issues"
+    "url": "https://github.com/sishenhei7/yorkie-pnpm/issues"
   },
-  "homepage": "https://github.com/yyx990803/yorkie",
+  "homepage": "https://github.com/sishenhei7/yorkie-pnpm",
   "devDependencies": {
     "jest": "^20.0.4",
     "mkdirp": "^0.5.1",

--- a/src/utils/find-dep-dir.js
+++ b/src/utils/find-dep-dir.js
@@ -1,12 +1,8 @@
-const path = require('path')
-
-function findDepDir() {
-  let depDir = path.join(__dirname, '..', '..')
-
+function findDepDir(depDir) {
   const projDir = depDir.split(/[\\/]/) // <- would split both on '/' and '\'
   const indexOfPnpmDir = projDir.indexOf('.pnpm')
   if (indexOfPnpmDir > -1) {
-    return projDir.slice(0, indexOfPnpmDir - 1).join('/');
+    return projDir.slice(0, indexOfPnpmDir).join('/') + '/yorkie';
   }
 
   return depDir

--- a/src/utils/find-dep-dir.js
+++ b/src/utils/find-dep-dir.js
@@ -1,0 +1,15 @@
+const path = require('path')
+
+function findDepDir() {
+  let depDir = path.join(__dirname, '..', '..')
+
+  const projDir = depDir.split(/[\\/]/) // <- would split both on '/' and '\'
+  const indexOfPnpmDir = projDir.indexOf('.pnpm')
+  if (indexOfPnpmDir > -1) {
+    return projDir.slice(0, indexOfPnpmDir - 1).join('/');
+  }
+
+  return depDir
+}
+
+module.exports = findDepDir


### PR DESCRIPTION
Pnpm uses copies of dependency and dependencies are stored in ```.pnpm``` folder.
When using pnpm, yorkie cannot correctly detect the ```depDir```. 
I fixed it in this pr.  